### PR TITLE
feat: add excludeImages list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           command: npm t
 
+      # TODO: "manually" copy a screenshot we want to use as social image
+
       # now let's see any changed files
       - name: See changed files 👀
         run: git status

--- a/README.md
+++ b/README.md
@@ -115,6 +115,26 @@ Is measured using image byte sizes. You can give the tolerance to consider the i
 
 The above setting considers the images that are within half percent in byte size to be the same.
 
+### Exclude images
+
+You might not want to copy every screenshot to the images folder. You can skip screenshots using their name by setting a list in the `cypress.json` configuration file:
+
+```json
+{
+  "env": {
+    "cypress-book": {
+      "excludeImages": ["social-image"]
+    }
+  }
+}
+```
+
+Later on, the screenshot "social-image" will be skipped
+
+```js
+cy.screenshot('social-image')
+```
+
 ## Debugging
 
 Run the tests with `DEBUG=cypress-book` environment variable to see verbose log messages using [debug](https://www.npmjs.com/package/debug) module.

--- a/cypress.json
+++ b/cypress.json
@@ -4,7 +4,8 @@
   "env": {
     "cypress-book": {
       "imageFolder": "images",
-      "tolerance": 0.005
+      "tolerance": 0.005,
+      "excludeImages": ["social-image"]
     }
   }
 }

--- a/cypress/integration/social-image-spec.js
+++ b/cypress/integration/social-image-spec.js
@@ -1,0 +1,13 @@
+/// <reference types="cypress" />
+describe('cypress-book social image', () => {
+  // GitHub suggests the resolution of 1280×640px for best display
+  it('captures an image', { viewportWidth: 1280, viewportHeight: 640 }, () => {
+    cy.visit('https://example.cypress.io')
+    cy.log('**checking the header ✅**')
+    cy.contains('h1', 'Kitchen Sink').should('be.visible')
+
+    cy.screenshot('social-image', {
+      clip: { x: 0, y: 0, width: 1280, height: 640 },
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "src"
   ],
   "scripts": {
-    "test": "cypress-expect run --passing 1",
+    "test": "cypress-expect run --passing 2",
     "cy:open": "cypress open",
     "semantic-release": "semantic-release"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,15 @@ const registerPlugin = (on, config) => {
       return
     }
 
+    const excludeImages = R.pathOr(
+      [],
+      ['env', 'cypress-book', 'excludeImages'],
+    )(config)
+    if (excludeImages.includes(details.name)) {
+      console.log('skipping copying excluded screenshot %s', details.name)
+      return
+    }
+
     const getImageFolderName = R.pathOr('images', [
       'env',
       'cypress-book',


### PR DESCRIPTION
You might not want to copy every screenshot to the images folder. You can skip screenshots using their name by setting a list in the `cypress.json` configuration file:

```json
{
  "env": {
    "cypress-book": {
      "excludeImages": ["social-image"]
    }
  }
}
```

Later on, the screenshot "social-image" will be skipped

```js
cy.screenshot('social-image')
```